### PR TITLE
PR: Modified pexpect constructor orden between OSes

### DIFF
--- a/spyder_terminal/server/logic/term_manager.py
+++ b/spyder_terminal/server/logic/term_manager.py
@@ -37,11 +37,12 @@ class TermManager(object):
     """Wrapper around pexpect to execute local commands."""
     def __init__(self):
         self.os = os.name
-        self.cmd = '/usr/bin/env bash'
-        self.pty_fork = pexpect.spawnu
         if self.os == WINDOWS:
             self.cmd = 'cmd'
             self.pty_fork = pspawn.PopenSpawn
+        else:
+            self.cmd = '/usr/bin/env bash'
+            self.pty_fork = pexpect.spawnu
         self.sockets = {}
         self.consoles = {}
 


### PR DESCRIPTION
Console manager constructor was failing on Windows due to a reference call to the class ``pexpect.spawnu``, which is inexistent on this OS