### PR TITLE
PR: Added more options for opening terminals at different locations

### DIFF
--- a/spyder_terminal/terminalplugin.py
+++ b/spyder_terminal/terminalplugin.py
@@ -251,16 +251,16 @@ class TerminalPlugin(SpyderPluginWidget):
             self.create_new_term()
 
     def set_project_path(self, path):
-        """Refresh current project path"""
+        """Refresh current project path."""
         self.project_path = path
         self.new_terminal_project.setEnabled(True)
 
     def set_current_opened_file(self, path):
-        """Get path of current opened file in editor"""
+        """Get path of current opened file in editor."""
         self.current_file_path = osp.dirname(path)
 
     def unset_project_path(self):
-        """Refresh current project path"""
+        """Refresh current project path."""
         self.project_path = None
         self.new_terminal_project.setEnabled(False)
 

--- a/spyder_terminal/widgets/terminalgui.py
+++ b/spyder_terminal/widgets/terminalgui.py
@@ -41,12 +41,7 @@ class TerminalWidget(QFrame):
         self.setLayout(layout)
 
         self.body = self.view.document
-        # if WEBENGINE:
-        #     self.body = self.view.page()
-        # else:
-        #     self.body = self.view.page().mainFrame()
 
-        self.font_setup = False
         self.view.page().loadFinished.connect(self.setup_term)
 
     @Slot(bool)


### PR DESCRIPTION
Fixes #45 
Now is possible to open terminals at the following locations:
* Current workspace folder
* Project folder (If present)
* Current opened file at editor