### PR TITLE
PR: Several installation fixes

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -2,4 +2,5 @@ include CHANGELOG.md
 include CONTRIBUTORS.md
 include LICENSE.txt
 include README.rst
+include setupbase.py
 recursive-include spyder_terminal/server/static *.html *.js *.json *.css *.eot *.tff *.woff *.woff2

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -8,6 +8,8 @@ To release a new version of spyder-terminal:
 
 * git add and git commit
 
+* python setup.py clean_components
+
 * python setup.py sdist upload
 
 * python setup.py bdist_wheel upload

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -12,7 +12,11 @@ To release a new version of spyder-terminal:
 
 * python setup.py sdist upload
 
-* python setup.py bdist_wheel upload
+* python3 setup.py bdist_wheel --plat-name win_amd64 upload
+
+* python3 setup.py bdist_wheel --plat-name win32 upload
+
+* python setup.py bdist_wheel --universal upload
 
 * git tag -a vX.X.X -m 'comment'
 

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,5 +1,2 @@
-[bdist_wheel]
-universal=1
-
 [aliases]
 install = build_static install

--- a/setup.py
+++ b/setup.py
@@ -8,6 +8,7 @@
 """Setup script for spyder_terminal."""
 
 # Standard library imports
+import ast
 import os
 
 # Third party imports
@@ -21,16 +22,17 @@ from setupbase import (BuildStatic,
 HERE = os.path.abspath(os.path.dirname(__file__))
 
 
-def get_version():
-    """Get version from source file"""
-    import codecs
-    with codecs.open("spyder_terminal/__init__.py", encoding="utf-8") as f:
-        lines = f.read().splitlines()
-        for l in lines:
-            if "__version__" in l:
-                version = l.split("=")[1].strip()
-                version = version.replace("'", '').replace('"', '')
-                return version
+def get_version(module='spyder_terminal'):
+    """Get version."""
+    with open(os.path.join(HERE, module, '__init__.py'), 'r') as f:
+        data = f.read()
+    lines = data.split('\n')
+    for line in lines:
+        if line.startswith('VERSION_INFO'):
+            version_tuple = ast.literal_eval(line.split('=')[-1].strip())
+            version = '.'.join(map(str, version_tuple))
+            break
+    return version
 
 
 def get_description():

--- a/setup.py
+++ b/setup.py
@@ -17,11 +17,19 @@ from setupbase import (DevelopWithBuildStatic,
                        SdistWithBuildStatic,
                        BuildStatic)
 
-# Loca imports
-from spyder_terminal import __version__
-
-
 HERE = os.path.abspath(os.path.dirname(__file__))
+
+
+def get_version():
+    """Get version from source file"""
+    import codecs
+    with codecs.open("spyder_terminal/__init__.py", encoding="utf-8") as f:
+        lines = f.read().splitlines()
+        for l in lines:
+            if "__version__" in l:
+                version = l.split("=")[1].strip()
+                version = version.replace("'", '').replace('"', '')
+                return version
 
 
 def get_description():
@@ -43,7 +51,7 @@ cmdclass = {
 
 setup(
     name='spyder_terminal',
-    version=__version__,
+    version=get_version(),
     cmdclass=cmdclass,
     keywords=['Spyder', 'Plugin'],
     url='https://github.com/spyder-ide/spyder-terminal',

--- a/setup.py
+++ b/setup.py
@@ -43,6 +43,10 @@ def get_description():
 REQUIREMENTS = ['spyder>=3.2.0.dev0', 'pexpect', 'tornado',
                 'coloredlogs', 'requests']
 
+if os.name == 'nt':
+    REQUIREMENTS.append('pywinpty')
+
+
 cmdclass = {
     'build_static': BuildStatic,
     'sdist': SdistWithBuildStatic,

--- a/setup.py
+++ b/setup.py
@@ -13,9 +13,10 @@ import os
 # Third party imports
 from setuptools import find_packages, setup
 
-from setupbase import (DevelopWithBuildStatic,
-                       SdistWithBuildStatic,
-                       BuildStatic)
+from setupbase import (BuildStatic,
+                       CleanComponents,
+                       SdistWithBuildStatic)
+
 
 HERE = os.path.abspath(os.path.dirname(__file__))
 
@@ -44,8 +45,8 @@ REQUIREMENTS = ['spyder>=3.2.0.dev0', 'pexpect', 'tornado',
 
 cmdclass = {
     'build_static': BuildStatic,
-    # 'develop': DevelopWithBuildStatic,
-    'sdist': SdistWithBuildStatic
+    'sdist': SdistWithBuildStatic,
+    'clean_components': CleanComponents
 }
 
 

--- a/setup.py
+++ b/setup.py
@@ -10,6 +10,7 @@
 # Standard library imports
 import ast
 import os
+import sys
 
 # Third party imports
 from setuptools import find_packages, setup
@@ -45,7 +46,7 @@ def get_description():
 REQUIREMENTS = ['spyder>=3.2.0.dev0', 'pexpect', 'tornado',
                 'coloredlogs', 'requests']
 
-if os.name == 'nt':
+if os.name == 'nt' or any([arg.startswith('win') for arg in sys.argv]):
     REQUIREMENTS.append('pywinpty')
 
 

--- a/setupbase.py
+++ b/setupbase.py
@@ -9,6 +9,7 @@ See: https://github.com/jupyter/notebook/blob/master/setupbase.py
 """
 
 import os
+import os.path as osp
 import sys
 import pipes
 
@@ -23,6 +24,11 @@ if sys.platform == 'win32':
 else:
     def list2cmdline(cmd_list):
         return ' '.join(map(pipes.quote, cmd_list))
+
+
+HERE = os.path.abspath(os.path.dirname(__file__))
+COMPONENTS = osp.join(HERE, 'spyder_terminal', 'server', 'static',
+                      'components')
 
 
 repo_root = os.path.dirname(os.path.abspath(__file__))
@@ -57,5 +63,6 @@ class BuildStatic(Command):
         pass
 
     def run(self):
-        log.info("running [bower install]")
-        run(['bower', 'install', '--allow-root'], cwd=repo_root)
+        if not osp.isdir(COMPONENTS):
+            log.info("running [bower install]")
+            run(['bower', 'install', '--allow-root'], cwd=repo_root)

--- a/setupbase.py
+++ b/setupbase.py
@@ -10,8 +10,9 @@ See: https://github.com/jupyter/notebook/blob/master/setupbase.py
 
 import os
 import os.path as osp
-import sys
 import pipes
+import shutil
+import sys
 
 from distutils import log
 from distutils.core import Command
@@ -41,18 +42,6 @@ def run(cmd, *args, **kwargs):
     return check_call(cmd, *args, **kwargs)
 
 
-class DevelopWithBuildStatic(develop):
-    def install_for_development(self):
-        self.run_command('build_static')
-        return develop.install_for_development(self)
-
-
-class SdistWithBuildStatic(sdist):
-    def make_distribution(self):
-        self.run_command('build_static')
-        return sdist.make_distribution(self)
-
-
 class BuildStatic(Command):
     user_options = []
 
@@ -66,3 +55,29 @@ class BuildStatic(Command):
         if not osp.isdir(COMPONENTS):
             log.info("running [bower install]")
             run(['bower', 'install', '--allow-root'], cwd=repo_root)
+
+
+class DevelopWithBuildStatic(develop):
+    def install_for_development(self):
+        self.run_command('build_static')
+        return develop.install_for_development(self)
+
+
+class SdistWithBuildStatic(sdist):
+    def make_distribution(self):
+        self.run_command('build_static')
+        return sdist.make_distribution(self)
+
+
+class CleanComponents(Command):
+    user_options = []
+
+    def initialize_options(self):
+        pass
+
+    def finalize_options(self):
+        pass
+
+    def run(self):
+        log.info("Removing server components")
+        shutil.rmtree(COMPONENTS)

--- a/spyder_terminal/__init__.py
+++ b/spyder_terminal/__init__.py
@@ -10,5 +10,6 @@
 from .terminalplugin import TerminalPlugin as PLUGIN_CLASS
 
 PLUGIN_CLASS
+
 VERSION_INFO = (0, 2, 0, 'dev0')
 __version__ = '.'.join(map(str, VERSION_INFO))

--- a/spyder_terminal/terminalplugin.py
+++ b/spyder_terminal/terminalplugin.py
@@ -13,7 +13,7 @@ import requests
 import subprocess
 import os.path as osp
 
-from qtpy import PYQT5
+from qtpy import PYQT4, PYSIDE
 from qtpy.QtWidgets import (QApplication, QMessageBox, QVBoxLayout, QMenu,
                             QShortcut)
 
@@ -37,7 +37,7 @@ from spyder_terminal.widgets.terminalgui import TerminalWidget
 # from spyder.py3compat import is_text_string, to_text_string
 from spyder.utils.misc import select_port
 
-from spyder.py3compat import getcwd
+from spyder.py3compat import PY2, getcwd
 from spyder.config.base import DEV
 
 LOCATION = osp.realpath(osp.join(os.getcwd(),
@@ -173,8 +173,11 @@ class TerminalPlugin(SpyderPluginWidget):
         """Check if current Qt backend version is greater or equal to 5."""
         message = ''
         valid = True
-        if not PYQT5:
-            message = 'Spyder-terminal does not work with Qt4'
+        if PYQT4 or PYSIDE:
+            message = 'This plugin does not work with Qt 4'
+            valid = False
+        elif WINDOWS and PY2:
+            message = 'This plugin does not work with Python 2 on Windows'
             valid = False
         return valid, message
 


### PR DESCRIPTION
Fixes #85 

----

@andfoy, please take a close look at the release instructions in RELEASE.md:

1. I added a command called `clean_components` to clean server JS components before building a new release.
2. With my additions you can build the Windows wheels on Linux (or any other platform :-). But you need to use the commands I posted in RELEASE.md for that.
3. We can build a single universal wheel for Mac and Linux. The good thing about pip is that it tries to install OS specific wheels first and then the universal ones.
4. I verified that with these fixes we can create conda packages. The previous versions can't be built with conda-build because you forgot to add setupbase.py to the gzip tarballs.