### PR TITLE
PR: Don't raise plugin when a new terminal is created

### DIFF
--- a/spyder_terminal/terminalplugin.py
+++ b/spyder_terminal/terminalplugin.py
@@ -357,7 +357,6 @@ class TerminalPlugin(SpyderPluginWidget):
         self.tabwidget.setTabToolTip(index, "Terminal {0}".format(num_term))
         if self.dockwidget and not self.ismaximized:
             self.dockwidget.setVisible(True)
-            self.dockwidget.raise_()
         self.activateWindow()
         widget.view.setFocus()
 


### PR DESCRIPTION
This was making the plugin to gain focus during Spyder startup, which was driving me crazy.