### PR TITLE
PR: Do not clean WebEngine cache when using WebKit

### DIFF
--- a/spyder_terminal/widgets/terminalgui.py
+++ b/spyder_terminal/widgets/terminalgui.py
@@ -144,7 +144,10 @@ class TermView(WebView):
 
         if WEBENGINE:
             self.document = self.page()
-            self.document.profile().clearHttpCache()
+            try:
+                self.document.profile().clearHttpCache()
+            except AttributeError:
+                pass
         else:
             self.document = self.page().mainFrame()
 


### PR DESCRIPTION
Fixes #114 