### PR TITLE
PR: Fix double scroll bar appearing in Linux

### DIFF
--- a/spyder_terminal/server/static/css/style.css
+++ b/spyder_terminal/server/static/css/style.css
@@ -16,10 +16,11 @@ h1 {
 }
 
 #terminal-container {
-    height:100vh;
+    height: 100vh;
     margin: 0px;
     padding: 0px;
     z-index: 255;
+    overflow: hidden;
 }
 
 #terminal-container .terminal {


### PR DESCRIPTION
With this minor change the double bar doesn't appear in the terminal in Linux

![image](https://user-images.githubusercontent.com/20992645/73275160-b7b17300-41b4-11ea-964c-ba110e922926.png)
