### PR TITLE
PR: Change default terminal for macOS Catalina

### DIFF
--- a/spyder_terminal/confpage.py
+++ b/spyder_terminal/confpage.py
@@ -7,10 +7,9 @@
 """Spyder terminal configuration page."""
 
 # Standard library imports
+from distutils.version import LooseVersion
 import os
 import platform
-
-from distutils.version import LooseVersion
 
 # Third party imports
 from qtpy.QtWidgets import (QVBoxLayout, QGroupBox, QGridLayout, QButtonGroup,

--- a/spyder_terminal/confpage.py
+++ b/spyder_terminal/confpage.py
@@ -10,8 +10,9 @@
 import os
 import platform
 
-# Third party imports
 from distutils.version import LooseVersion
+
+# Third party imports
 from qtpy.QtWidgets import (QVBoxLayout, QGroupBox, QGridLayout, QButtonGroup,
                             QRadioButton, QWidget)
 from spyder.api.preferences import PluginConfigPage

--- a/spyder_terminal/confpage.py
+++ b/spyder_terminal/confpage.py
@@ -8,8 +8,10 @@
 
 # Standard library imports
 import os
+import platform
 
 # Third party imports
+from distutils.version import LooseVersion
 from qtpy.QtWidgets import (QVBoxLayout, QGroupBox, QGridLayout, QButtonGroup,
                             QRadioButton, QWidget)
 from spyder.api.preferences import PluginConfigPage
@@ -45,10 +47,15 @@ class TerminalConfigPage(PluginConfigPage):
         valid_shells = zip(valid_shells, valid_shells)
         if WINDOWS:
             default_option = 'cmd'
-        elif sys.platform == 'linux':
+        elif sys.platform.startswith('linux'):
             default_option = 'bash'
         else:
-            default_option = 'zsh'
+            mac_ver = LooseVersion(platform.mac_ver()[0])
+            if mac_ver >= LooseVersion('10.15.0'):
+                # Catalina changed the default shell to zsh
+                default_option = 'zsh'
+            else:
+                default_option = 'bash'
         shell_combo = self.create_combobox(_("Select the shell interpreter:"),
                                            valid_shells, 'shell', restart=True,
                                            default=default_option)

--- a/spyder_terminal/confpage.py
+++ b/spyder_terminal/confpage.py
@@ -43,7 +43,12 @@ class TerminalConfigPage(PluginConfigPage):
             if find_program(shell) is not None:
                 valid_shells.append(shell)
         valid_shells = zip(valid_shells, valid_shells)
-        default_option = 'cmd' if WINDOWS else 'bash'
+        if WINDOWS:
+            default_option = 'cmd'
+        elif sys.platform == 'linux':
+            default_option = 'bash'
+        else:
+            default_option = 'zsh'
         shell_combo = self.create_combobox(_("Select the shell interpreter:"),
                                            valid_shells, 'shell', restart=True,
                                            default=default_option)


### PR DESCRIPTION
Taking into account that the default terminal for Catalina is `zsh`, change the default option for macOS to `zsh`.

We are not able to get the login shell correctly using `echo $SHELL` or equivalent methods on the terminal because they are not reliable as seen in the following image.

![image](https://user-images.githubusercontent.com/20992645/78862863-eb531980-79fd-11ea-8502-c7b912e23af0.png)

Fixes #177 
