### PR TITLE
PR: Update release instructions with new loghub command

### DIFF
--- a/RELEASE.md
+++ b/RELEASE.md
@@ -2,11 +2,11 @@ To release a new version of spyder-terminal:
 
 * git fetch upstream && git merge upstream/master
 
-* Close milestone on Github
+* Close milestone on Zenhub
 
 * git clean -xfdi
 
-* Update CHANGELOG.md with `loghub -m <milestone> -u <github-user> spyder-ide/spyder-terminal`
+* Update CHANGELOG.md with `loghub spyder-ide/spyder-terminal -zr "spyder-terminal vX.X.X"`
 
 * git add and git commit with "Update Changelog"
 


### PR DESCRIPTION
@steff456, this is the new way to generate our Changelog with Zenhub.

You also need to create a file called `~/.loghubrc` with the following content:

```ini
[github]
token = 

[zenhub]
token = 
```

For the Github part, you need to create a [personal access token](https://github.com/settings/tokens) and add it to it. For the Zenhub part, I'll send you the token privately.