### PR TITLE
PR: Add compatibility with the latest release of xterm

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -1,6 +1,7 @@
 Spyder-Terminal
 ===============
 
+
 Project status
 --------------
 

--- a/package.json
+++ b/package.json
@@ -13,11 +13,11 @@
     "fetch": "github/fetch#^2.0.3",
     "jquery": "jquery/jquery-dist#^3.2.1",
     "promise-polyfill": "taylorhakes/promise-polyfill#^6.0.2",
-    "xterm": "^4.5.0",
-    "xterm-addon-attach": "^0.3.0",
-    "xterm-addon-fit": "^0.3.0",
-    "xterm-addon-search": "^0.3.0",
-    "xterm-addon-web-links": "^0.2.1",
+    "xterm": "4.5.0",
+    "xterm-addon-attach": "0.3.0",
+    "xterm-addon-fit": "0.3.0",
+    "xterm-addon-search": "0.3.0",
+    "xterm-addon-web-links": "0.2.1",
     "xterm.js": "sourcelair/xterm.js#^3.14.5"
   },
   "engines": {

--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
     "fetch": "github/fetch#^2.0.3",
     "jquery": "jquery/jquery-dist#^3.2.1",
     "promise-polyfill": "taylorhakes/promise-polyfill#^6.0.2",
-    "xterm": "^4.4.0",
+    "xterm": "^4.5.0",
     "xterm-addon-attach": "^0.3.0",
     "xterm-addon-fit": "^0.3.0",
     "xterm-addon-search": "^0.3.0",

--- a/spyder_terminal/server/static/js/main.js
+++ b/spyder_terminal/server/static/js/main.js
@@ -133,7 +133,7 @@ function setcwd(cwd) {
 function getTerminalLines(){
   let text = '';
   for(let row = 0; row < term.rows; row++){
-    let actLine = term.buffer.getLine(row);
+    let actLine = term.buffer.active.getLine(row);
     let length = actLine._line.length;
     text += actLine.translateToString(false, 0, length) + '';
   }


### PR DESCRIPTION
Fix the change in the API of the buffer created in xterm 4.5.0 version