### PR TITLE
PR: Import sys for confpage

### DIFF
--- a/spyder_terminal/confpage.py
+++ b/spyder_terminal/confpage.py
@@ -10,6 +10,7 @@
 from distutils.version import LooseVersion
 import os
 import platform
+import sys
 
 # Third party imports
 from qtpy.QtWidgets import (QVBoxLayout, QGroupBox, QGridLayout, QButtonGroup,


### PR DESCRIPTION
The confpage is missing an import and is thus not displayed in the spyder settings.

```
  File "/usr/lib/python3.8/site-packages/spyder/app/mainwindow.py", line 3175, in show_preferences
    widget = plugin._create_configwidget(dlg, self)
  File "/usr/lib/python3.8/site-packages/spyder/plugins/base.py", line 117, in _create_configwidget
    configwidget.initialize()
  File "/usr/lib/python3.8/site-packages/spyder/preferences/configdialog.py", line 72, in initialize
    self.load_from_conf()
  File "/usr/lib/python3.8/site-packages/spyder/preferences/configdialog.py", line 327, in load_from_conf
    checkbox.setChecked(self.get_option(option, default, section=sec))
TypeError: setChecked(self, bool): argument 1 has unexpected type 'str'
Traceback (most recent call last):
  File "/usr/lib/python3.8/site-packages/spyder/app/mainwindow.py", line 3175, in show_preferences
    widget = plugin._create_configwidget(dlg, self)
  File "/usr/lib/python3.8/site-packages/spyder/plugins/base.py", line 117, in _create_configwidget
    configwidget.initialize()
  File "/usr/lib/python3.8/site-packages/spyder/preferences/configdialog.py", line 72, in initialize
    self.load_from_conf()
  File "/usr/lib/python3.8/site-packages/spyder/preferences/configdialog.py", line 327, in load_from_conf
    checkbox.setChecked(self.get_option(option, default, section=sec))
TypeError: setChecked(self, bool): argument 1 has unexpected type 'str'
Traceback (most recent call last):
  File "/usr/lib/python3.8/site-packages/spyder/app/mainwindow.py", line 3175, in show_preferences
    widget = plugin._create_configwidget(dlg, self)
  File "/usr/lib/python3.8/site-packages/spyder/plugins/base.py", line 117, in _create_configwidget
    configwidget.initialize()
  File "/usr/lib/python3.8/site-packages/spyder/preferences/configdialog.py", line 71, in initialize
    self.setup_page()
  File "/usr/lib/python3.8/site-packages/spyder_terminal/confpage.py", line 50, in setup_page
    elif sys.platform.startswith('linux'):
NameError: name 'sys' is not defined
```