### PR TITLE
PR: Move Spyder-terminal plugin to Python 3

### DIFF
--- a/spyder_terminal/server/logic/term_manager.py
+++ b/spyder_terminal/server/logic/term_manager.py
@@ -1,9 +1,6 @@
 # -*- coding: utf-8 -*-
 
 """Term manager."""
-
-from __future__ import unicode_literals
-
 import os
 import time
 import signal
@@ -45,12 +42,13 @@ class TermManager(TermManagerBase):
 
     def __init__(self, shell_command, **kwargs):
         """Create a new terminal handler instance."""
-        super(TermManager, self).__init__(shell_command, **kwargs)
+        super().__init__(shell_command, **kwargs)
         self.consoles = {}
 
     def new_terminal(self, **options):
         """Make a new terminal, return a :class:`PtyReader` instance."""
-        tty = super(TermManager, self).new_terminal(**options)
+        # tty = super(TermManager, self).new_terminal(**options)
+        tty = super().new_terminal(**options)
         return PtyReader(tty.ptyproc)
 
     @tornado.gen.coroutine

--- a/spyder_terminal/server/logic/term_manager.py
+++ b/spyder_terminal/server/logic/term_manager.py
@@ -47,7 +47,6 @@ class TermManager(TermManagerBase):
 
     def new_terminal(self, **options):
         """Make a new terminal, return a :class:`PtyReader` instance."""
-        # tty = super(TermManager, self).new_terminal(**options)
         tty = super().new_terminal(**options)
         return PtyReader(tty.ptyproc)
 

--- a/spyder_terminal/server/tests/test_server.py
+++ b/spyder_terminal/server/tests/test_server.py
@@ -8,13 +8,8 @@ Note: This uses tornado.testing unittest style tests
 import os
 import sys
 import os.path as osp
+from urllib.parse import urlencode
 
-PY3 = sys.version_info[0] == 3
-
-if PY3:
-    from urllib.parse import urlencode
-else:
-    from urllib import urlencode
 
 import pytest
 from flaky import flaky

--- a/spyder_terminal/terminalplugin.py
+++ b/spyder_terminal/terminalplugin.py
@@ -30,7 +30,6 @@ from spyder.utils.qthelpers import (add_actions, create_action,
                                     create_toolbutton,
                                     MENU_SEPARATOR)
 from spyder.widgets.tabs import Tabs
-from spyder.py3compat import PY2, getcwd
 from spyder.utils.misc import select_port
 
 # Local imports
@@ -73,8 +72,8 @@ class TerminalPlugin(SpyderPluginWidget):
         self.CONF = CONF
         self.server_stdout = subprocess.PIPE
         self.server_stderr = subprocess.PIPE
-        self.stdout_file = osp.join(getcwd(), 'spyder_terminal_out.log')
-        self.stderr_file = osp.join(getcwd(), 'spyder_terminal_err.log')
+        self.stdout_file = osp.join(os.getcwd(), 'spyder_terminal_out.log')
+        self.stderr_file = osp.join(os.getcwd(), 'spyder_terminal_err.log')
         if get_debug_level() > 0:
             self.server_stdout = open(self.stdout_file, 'w')
             self.server_stderr = open(self.stderr_file, 'w')
@@ -91,7 +90,7 @@ class TerminalPlugin(SpyderPluginWidget):
 
         self.project_path = None
         self.current_file_path = None
-        self.current_cwd = getcwd()
+        self.current_cwd = os.getcwd()
 
         try:
             # Spyder 3

--- a/spyder_terminal/tests/test_terminal.py
+++ b/spyder_terminal/tests/test_terminal.py
@@ -21,7 +21,6 @@ os.environ['SPYDER_DEV'] = 'True'
 # Local imports
 import spyder_terminal.terminalplugin
 from spyder_terminal.terminalplugin import TerminalPlugin
-from spyder.py3compat import getcwd
 
 LOCATION = os.path.realpath(os.path.join(os.getcwd(),
                                          os.path.dirname(__file__)))
@@ -184,8 +183,8 @@ def test_output_redirection(setup_terminal, qtbot_module):
     """Test if stdout and stderr are redirected on DEV mode."""
     assert spyder_terminal.terminalplugin.get_debug_level() > 0
 
-    stdout = osp.join(getcwd(), 'spyder_terminal_out.log')
-    stderr = osp.join(getcwd(), 'spyder_terminal_err.log')
+    stdout = osp.join(os.getcwd(), 'spyder_terminal_out.log')
+    stderr = osp.join(os.getcwd(), 'spyder_terminal_err.log')
     assert osp.exists(stdout) and osp.exists(stderr)
     # terminal.closing_plugin()
 

--- a/spyder_terminal/widgets/terminalgui.py
+++ b/spyder_terminal/widgets/terminalgui.py
@@ -6,9 +6,6 @@
 # (see LICENSE.txt for details)
 # -----------------------------------------------------------------------------
 """Terminal Widget."""
-
-from __future__ import print_function
-
 # Standard library imports
 import sys
 


### PR DESCRIPTION
Remove compatibility with python 2

- [x] Update super() use
- [x] Remove the py3compat module
- [x] Update any code (and remove if necessary) that uses if PY2 etc...
- [x] Check division operator
- [x] Remove future imports
- [x] Check tests
- [x] Check for Py2 of Py3 codes

Fixes #212 