### PR TITLE
PR: Fix highlight text on the terminal

### DIFF
--- a/spyder_terminal/server/static/js/main.js
+++ b/spyder_terminal/server/static/js/main.js
@@ -244,6 +244,7 @@ const term_functions = {
   searchPrevious: searchPrevious,
   setOption: setOption,
   addClassStyleToContainer: addClassStyleToContainer,
+  hexToRGB: hexToRGB,
 };
 
 export default term_functions;

--- a/spyder_terminal/server/static/js/main.js
+++ b/spyder_terminal/server/static/js/main.js
@@ -175,11 +175,19 @@ function isAlive() {
   return alive;
 }
 
+function hexToRGB(hex) {
+  let r = parseInt(hex.slice(1, 3), 16);
+  let g = parseInt(hex.slice(3, 5), 16);
+  let b = parseInt(hex.slice(5, 7), 16);
+  return "rgba(" + r + ", " + g + ", " + b + ", " + 0.2 + ")";
+}
+
 function setOption(option_name, option) {
-  term.setOption(option_name, option);
   if(option_name === 'theme'){
     curTheme = option;
+    option['selection'] = hexToRGB(option['selection']);
   }
+  term.setOption(option_name, option);
 }
 
 function runRealTerminal() {

--- a/spyder_terminal/tests/test_terminal.py
+++ b/spyder_terminal/tests/test_terminal.py
@@ -74,6 +74,24 @@ def check_fonts(term, expected):
         return fonts == expected
 
 
+def check_hex_to_rgb(term):
+    """Check if terminal is converting hexa colors to rgb correctly."""
+    if WEBENGINE:
+        def callback(data):
+            global hex_to_rgb
+            hex_to_rgb = data
+        expected = 'rgba(170, 171, 33, 0.2)'
+        color = '#aaab21'
+        term.body.runJavaScript(PREFIX + "hexToRGB('{}')".format(color),
+                                callback)
+        try:
+            return hex_to_rgb == expected
+        except NameError:
+            return False
+    else:
+        return True
+
+
 def check_num_tabs(terminal, ref_value):
     """Check if total number of terminal tabs has changed."""
     value = len(terminal.get_terms())
@@ -102,6 +120,19 @@ def setup_terminal(qtbot_module, request):
 
     request.addfinalizer(teardown)
     return terminal
+
+
+def test_terminal_color(setup_terminal, qtbot_module):
+    """Test if the terminal color is converting to rgba correctly."""
+    terminal = setup_terminal
+    qtbot_module.waitUntil(lambda: terminal.server_is_ready(), timeout=TERM_UP)
+    qtbot_module.wait(1000)
+
+    term = terminal.get_current_term()
+    port = terminal.port
+    status_code = requests.get('http://127.0.0.1:{}'.format(port)).status_code
+    assert status_code == 200
+    qtbot_module.waitUntil(lambda: check_hex_to_rgb(term),  timeout=TERM_UP)
 
 
 def test_terminal_font(setup_terminal, qtbot_module):


### PR DESCRIPTION
Update the selection theme color in rgba format instead of hex. In this way the transparency is added to the themes.

Fixes #202 

Idle
![image](https://user-images.githubusercontent.com/20992645/85777951-b5adfa80-b6e7-11ea-8ad9-73995d7d419b.png)

Spyder
![image](https://user-images.githubusercontent.com/20992645/85778100-d8d8aa00-b6e7-11ea-8f55-8b312d914828.png)

Spyder Dark
![image](https://user-images.githubusercontent.com/20992645/85778209-f6a60f00-b6e7-11ea-89d7-ad47113be966.png)

Pastel
![image](https://user-images.githubusercontent.com/20992645/85778295-0e7d9300-b6e8-11ea-9a7d-00df91700b0b.png)
