### PR TITLE
PR: Add option to zoom in/zoom out in the terminal

### DIFF
--- a/spyder_terminal/config.py
+++ b/spyder_terminal/config.py
@@ -28,6 +28,8 @@ CONF_DEFAULTS = [
       'terminal/paste': 'Ctrl+Alt+Shift+V' if LINUX else 'Ctrl+Alt+V',
       'terminal/new_term': 'Ctrl+Alt+T',
       'terminal/clear': 'Ctrl+Alt+K',
+      'terminal/increase_font': 'Ctrl++',
+      'terminal/decrease_font': 'Ctrl+-',
      }
      ),
 ]

--- a/spyder_terminal/server/static/js/main.js
+++ b/spyder_terminal/server/static/js/main.js
@@ -14,6 +14,7 @@ let pid;
 let curFont;
 let curTheme;
 let alive;
+let fontSize;
 
 let myHeaders = new Headers();
 myHeaders.append("Content-Type", "application/x-www-form-urlencoded");
@@ -70,6 +71,8 @@ function createTerminal(){
 
   let cols = term.cols;
   let rows = term.rows;
+
+  fontSize = term.getOption('fontSize');
 
   fetch('/api/terminals?cols=' + cols + '&rows=' + rows, {
     method: 'POST',
@@ -175,6 +178,18 @@ function isAlive() {
   return alive;
 }
 
+function increaseFontSize(){
+  fontSize += 1;
+  setOption('fontSize', fontSize);
+  fitAddon.fit();
+}
+
+function decreaseFontSize(){
+  fontSize -= 1;
+  setOption('fontSize', fontSize);
+  fitAddon.fit();
+}
+
 function setOption(option_name, option) {
   term.setOption(option_name, option);
   if(option_name === 'theme'){
@@ -235,6 +250,8 @@ const term_functions = {
   searchNext: searchNext,
   searchPrevious: searchPrevious,
   setOption: setOption,
+  increaseFontSize: increaseFontSize,
+  decreaseFontSize: decreaseFontSize,
   addClassStyleToContainer: addClassStyleToContainer,
 };
 

--- a/spyder_terminal/server/static/js/main.js
+++ b/spyder_terminal/server/static/js/main.js
@@ -190,6 +190,7 @@ function decreaseFontSize(){
   setOption('fontSize', fontSize);
   fitAddon.fit();
   return fontSize;
+}
 
 function hexToRGB(hex) {
   let r = parseInt(hex.slice(1, 3), 16);

--- a/spyder_terminal/server/static/js/main.js
+++ b/spyder_terminal/server/static/js/main.js
@@ -182,12 +182,14 @@ function increaseFontSize(){
   fontSize += 1;
   setOption('fontSize', fontSize);
   fitAddon.fit();
+  return fontSize;
 }
 
 function decreaseFontSize(){
   fontSize -= 1;
   setOption('fontSize', fontSize);
   fitAddon.fit();
+  return fontSize;
 }
 
 function setOption(option_name, option) {

--- a/spyder_terminal/tests/test_terminal.py
+++ b/spyder_terminal/tests/test_terminal.py
@@ -57,6 +57,30 @@ def check_pwd(termwidget):
         return LOCATION in termwidget.body.toHtml()
 
 
+def check_increase_font_size(term):
+    def callback(data):
+        global font_size
+        font_size = data
+    expected = 16
+    term.body.runJavaScript(PREFIX + "increaseFontSize()", callback)
+    try:
+        return font_size == expected
+    except NameError:
+        return False
+
+
+def check_decrease_font_size(term):
+    def callback(data):
+        global font_size
+        font_size = data
+    expected = 15
+    term.body.runJavaScript(PREFIX + "decreaseFontSize()", callback)
+    try:
+        return font_size == expected
+    except NameError:
+        return False
+
+
 def check_fonts(term, expected):
     """Check if terminal fonts were updated."""
     if WEBENGINE:
@@ -118,6 +142,12 @@ def test_terminal_font(setup_terminal, qtbot_module):
     term.set_font('Ubuntu Mono')
     expected = '\'Ubuntu Mono\', monospace'
     qtbot_module.waitUntil(lambda: check_fonts(term, expected),
+                           timeout=TERM_UP)
+    # Verify increase of size of font
+    qtbot_module.waitUntil(lambda: check_increase_font_size(term),
+                           timeout=TERM_UP)
+    # Verify decrease of size of font
+    qtbot_module.waitUntil(lambda: check_decrease_font_size(term),
                            timeout=TERM_UP)
     #terminal.closing_plugin()
 

--- a/spyder_terminal/tests/test_terminal.py
+++ b/spyder_terminal/tests/test_terminal.py
@@ -60,10 +60,10 @@ def check_increase_font_size(term):
     def callback(data):
         global font_size
         font_size = data
-    expected = 16
+    expected = 15
     term.body.runJavaScript(PREFIX + "increaseFontSize()", callback)
     try:
-        return font_size == expected
+        return font_size > expected
     except NameError:
         return False
 
@@ -72,10 +72,10 @@ def check_decrease_font_size(term):
     def callback(data):
         global font_size
         font_size = data
-    expected = 15
+    expected = 16
     term.body.runJavaScript(PREFIX + "decreaseFontSize()", callback)
     try:
-        return font_size == expected
+        return font_size < expected
     except NameError:
         return False
 

--- a/spyder_terminal/widgets/terminalgui.py
+++ b/spyder_terminal/widgets/terminalgui.py
@@ -253,6 +253,14 @@ class TermView(WebView):
         """Clear the terminal."""
         self.eval_javascript('clearTerm()')
 
+    def increase_font(self):
+        """Increase terminal font."""
+        return self.eval_javascript('increaseFontSize()')
+
+    def decrease_font(self):
+        """Decrease terminal font."""
+        return self.eval_javascript('decreaseFontSize()')
+
     def contextMenuEvent(self, event):
         """Override Qt method."""
         menu = QMenu(self)
@@ -309,6 +317,12 @@ class TermView(WebView):
                 self.paste()
             elif sequence == self.CONF.get_shortcut(CONF_SECTION, 'clear'):
                 self.clear()
+            elif sequence == self.CONF.get_shortcut(
+                    CONF_SECTION, 'increase_font'):
+                self.increase_font()
+            elif sequence == self.CONF.get_shortcut(
+                    CONF_SECTION, 'decrease_font'):
+                self.decrease_font()
             else:
                 event.ignore()
                 return False

--- a/spyder_terminal/widgets/terminalgui.py
+++ b/spyder_terminal/widgets/terminalgui.py
@@ -219,6 +219,12 @@ class TermView(WebView):
             self, _("Clear Terminal"),
             triggered=self.clear,
             shortcut=self.CONF.get_shortcut(CONF_SECTION, 'clear'))
+        self.zoom_in = create_action(
+            self, _("Zoom in"), triggered=self.increase_font,
+            shortcut=self.CONF.get_shortcut(CONF_SECTION, 'increase_font'))
+        self.zoom_out = create_action(
+            self, _("Zoom out"), triggered=self.decrease_font,
+            shortcut=self.CONF.get_shortcut(CONF_SECTION, 'decrease_font'))
         if WEBENGINE:
             self.channel = QWebChannel(self.page())
             self.page().setWebChannel(self.channel)
@@ -262,7 +268,8 @@ class TermView(WebView):
         """Override Qt method."""
         menu = QMenu(self)
         actions = [self.pageAction(QWebEnginePage.SelectAll),
-                   self.copy_action, self.paste_action]
+                   self.copy_action, self.paste_action, None, self.zoom_in,
+                   self.zoom_out]
         if DEV and not WEBENGINE:
             settings = self.page().settings()
             settings.setAttribute(QWebEngineSettings.DeveloperExtrasEnabled,


### PR DESCRIPTION
Now the user can zoom in or zoom out of the terminal with `Ctrl++` and `Ctrl+-` shortcuts

Fixes #148 

![zoom](https://user-images.githubusercontent.com/20992645/85802909-89a47080-b70b-11ea-99aa-c1d4bc1bb462.gif)

