### PR TITLE
PR: Fix shortcuts to new API

### DIFF
--- a/spyder_terminal/config.py
+++ b/spyder_terminal/config.py
@@ -26,10 +26,10 @@ CONF_DEFAULTS = [
      {
       'terminal/copy': 'Ctrl+Alt+Shift+C' if LINUX else 'Ctrl+Alt+C',
       'terminal/paste': 'Ctrl+Alt+Shift+V' if LINUX else 'Ctrl+Alt+V',
-      'terminal/new_term': 'Ctrl+Alt+T',
+      'terminal/new terminal': 'Ctrl+Alt+T',
       'terminal/clear': 'Ctrl+Alt+K',
-      'terminal/increase_font': 'Ctrl++',
-      'terminal/decrease_font': 'Ctrl+-',
+      'terminal/zoom in': 'Ctrl++',
+      'terminal/zoom out': 'Ctrl+-',
      }
      ),
 ]
@@ -41,4 +41,4 @@ CONF_DEFAULTS = [
 #    or if you want to *rename* options, then you need to do a MAJOR update in
 #    version, e.g. from 1.0.0 to 2.0.0
 # 3. You don't need to touch this value if you're just adding a new option
-CONF_VERSION = '1.0.0'
+CONF_VERSION = '2.0.0'

--- a/spyder_terminal/terminalplugin.py
+++ b/spyder_terminal/terminalplugin.py
@@ -126,11 +126,6 @@ class TerminalPlugin(SpyderPluginWidget):
         layout.addWidget(self.tabwidget)
         self.setLayout(layout)
 
-        new_term_shortcut = QShortcut(
-            CONF.get_shortcut(CONF_SECTION, 'new_term'),
-            self, self.create_new_term)
-        new_term_shortcut.setContext(Qt.WidgetWithChildrenShortcut)
-
         self.color_scheme = CONF.get('appearance', 'ui_theme')
         self.theme = CONF.get('appearance', 'selected')
 
@@ -217,7 +212,8 @@ class TerminalPlugin(SpyderPluginWidget):
                                                "the current working "
                                                "directory"),
                                          triggered=self.create_new_term)
-
+        self.register_shortcut(new_terminal_cwd, context='terminal',
+                               name='new terminal')
         self.new_terminal_project = create_action(self,
                                                   _("New terminal in current "
                                                     "project"),
@@ -336,6 +332,7 @@ class TerminalPlugin(SpyderPluginWidget):
         font = self.get_font()
         term = TerminalWidget(self, self.port, path=path, font=font.family(),
                               theme=self.theme, color_scheme=self.color_scheme)
+        self.register_widget_shortcuts(term)
         self.add_tab(term)
         term.terminal_closed.connect(lambda: self.close_term(term=term))
 

--- a/spyder_terminal/tests/test_terminal.py
+++ b/spyder_terminal/tests/test_terminal.py
@@ -12,9 +12,12 @@ import os
 import pytest
 import requests
 import os.path as osp
-from pytestqt.plugin import QtBot
-from qtpy.QtWebEngineWidgets import WEBENGINE
 from flaky import flaky
+from pytestqt.plugin import QtBot
+from unittest.mock import Mock
+from qtpy.QtWebEngineWidgets import WEBENGINE
+from qtpy.QtWidgets import QMainWindow
+
 
 os.environ['SPYDER_DEV'] = 'True'
 
@@ -131,7 +134,15 @@ def qtbot_module(qapp, request):
 @pytest.fixture(scope='module')
 def setup_terminal(qtbot_module, request):
     """Set up the Notebook plugin."""
-    terminal = TerminalPlugin(None)
+    class MainMock(QMainWindow):
+        def __getattr__(self, attr):
+            return Mock()
+
+        def register_shortcut(self, *args, **kwargs):
+            pass
+
+    main = MainMock()
+    terminal = TerminalPlugin(main)
     qtbot_module.addWidget(terminal)
     qtbot_module.waitUntil(lambda: terminal.server_is_ready(), timeout=TERM_UP)
     qtbot_module.wait(5000)

--- a/spyder_terminal/widgets/terminalgui.py
+++ b/spyder_terminal/widgets/terminalgui.py
@@ -78,6 +78,7 @@ class TerminalWidget(QFrame):
         self.theme = theme
         self.color_scheme = color_scheme
         self.parent = parent
+        self.shortcuts = self.create_shortcuts()
         layout = QVBoxLayout()
         layout.addWidget(self.view)
         layout.setContentsMargins(0, 0, 0, 0)
@@ -103,6 +104,20 @@ class TerminalWidget(QFrame):
         for option in options:
             dict_options[option] = self.parent.get_option(option)
         self.apply_settings(dict_options)
+
+    def create_shortcuts(self):
+        """Create the terminal shortcuts."""
+        return self.view.create_shortcuts()
+
+    def get_shortcut_data(self):
+        """
+        Return shortcut data, a list of tuples (shortcut, text, default).
+
+        shortcut (QShortcut or QAction instance)
+        text (string): action/shortcut description
+        default (string): default key sequence
+        """
+        return self.view.get_shortcut_data()
 
     def eval_javascript(self, script):
         """Evaluate Javascript instructions inside view."""
@@ -206,25 +221,7 @@ class TermView(WebView):
         WebView.__init__(self, parent)
         self.parent = parent
         self.CONF = CONF
-        self.copy_action = create_action(
-            self, _("Copy text"), icon=ima.icon('editcopy'),
-            triggered=self.copy,
-            shortcut=self.CONF.get_shortcut(CONF_SECTION, 'copy'))
-        self.paste_action = create_action(
-            self, _("Paste text"),
-            icon=ima.icon('editpaste'),
-            triggered=self.paste,
-            shortcut=self.CONF.get_shortcut(CONF_SECTION, 'paste'))
-        self.clear_action = create_action(
-            self, _("Clear Terminal"),
-            triggered=self.clear,
-            shortcut=self.CONF.get_shortcut(CONF_SECTION, 'clear'))
-        self.zoom_in = create_action(
-            self, _("Zoom in"), triggered=self.increase_font,
-            shortcut=self.CONF.get_shortcut(CONF_SECTION, 'increase_font'))
-        self.zoom_out = create_action(
-            self, _("Zoom out"), triggered=self.decrease_font,
-            shortcut=self.CONF.get_shortcut(CONF_SECTION, 'decrease_font'))
+        self.shortcuts = self.create_shortcuts()
         if WEBENGINE:
             self.channel = QWebChannel(self.page())
             self.page().setWebChannel(self.channel)
@@ -264,12 +261,71 @@ class TermView(WebView):
         """Decrease terminal font."""
         return self.eval_javascript('decreaseFontSize()')
 
+    def create_shortcuts(self):
+        """Create the terminal shortcuts."""
+        copy_shortcut = self.CONF.config_shortcut(
+            lambda: self.copy(),
+            context='terminal',
+            name='copy',
+            parent=self)
+        paste_shortcut = self.CONF.config_shortcut(
+            lambda: self.paste(),
+            context='terminal',
+            name='paste',
+            parent=self)
+        clear_shortcut = self.CONF.config_shortcut(
+            lambda: self.clear(),
+            context='terminal',
+            name='clear',
+            parent=self)
+        zoomin_shortcut = self.CONF.config_shortcut(
+            lambda: self.increase_font(),
+            context='terminal',
+            name='zoom in',
+            parent=self)
+        zoomout_shortcut = self.CONF.config_shortcut(
+            lambda: self.decrease_font(),
+            context='terminal',
+            name='zoom out',
+            parent=self)
+        return [copy_shortcut, paste_shortcut, clear_shortcut, zoomin_shortcut,
+                zoomout_shortcut]
+
+    def get_shortcut_data(self):
+        """
+        Return shortcut data, a list of tuples (shortcut, text, default).
+
+        shortcut (QShortcut or QAction instance)
+        text (string): action/shortcut description
+        default (string): default key sequence
+        """
+        return [sc.data for sc in self.shortcuts]
+
     def contextMenuEvent(self, event):
         """Override Qt method."""
+        copy_action = create_action(
+            self, _("Copy text"), icon=ima.icon('editcopy'),
+            triggered=self.copy,
+            shortcut=self.CONF.get_shortcut(CONF_SECTION, 'copy'))
+        paste_action = create_action(
+            self, _("Paste text"),
+            icon=ima.icon('editpaste'),
+            triggered=self.paste,
+            shortcut=self.CONF.get_shortcut(CONF_SECTION, 'paste'))
+        clear_action = create_action(
+            self, _("Clear Terminal"),
+            triggered=self.clear,
+            shortcut=self.CONF.get_shortcut(CONF_SECTION, 'clear'))
+        zoom_in = create_action(
+            self, _("Zoom in"), triggered=self.increase_font,
+            shortcut=self.CONF.get_shortcut(CONF_SECTION, 'zoom in'))
+        zoom_out = create_action(
+            self, _("Zoom out"), triggered=self.decrease_font,
+            shortcut=self.CONF.get_shortcut(CONF_SECTION, 'zoom out'))
         menu = QMenu(self)
         actions = [self.pageAction(QWebEnginePage.SelectAll),
-                   self.copy_action, self.paste_action, None, self.zoom_in,
-                   self.zoom_out]
+                   copy_action, paste_action, clear_action, None, zoom_in,
+                   zoom_out]
         if DEV and not WEBENGINE:
             settings = self.page().settings()
             settings.setAttribute(QWebEngineSettings.DeveloperExtrasEnabled,
@@ -322,10 +378,10 @@ class TermView(WebView):
             elif sequence == self.CONF.get_shortcut(CONF_SECTION, 'clear'):
                 self.clear()
             elif sequence == self.CONF.get_shortcut(
-                    CONF_SECTION, 'increase_font'):
+                    CONF_SECTION, 'zoom in'):
                 self.increase_font()
             elif sequence == self.CONF.get_shortcut(
-                    CONF_SECTION, 'decrease_font'):
+                    CONF_SECTION, 'zoom out'):
                 self.decrease_font()
             else:
                 event.ignore()


### PR DESCRIPTION
The shortcuts are visible again in the Preferences pane for the user to change the key combinations

<img width="1054" alt="Captura de Pantalla 2020-06-29 a la(s) 4 04 48 p  m" src="https://user-images.githubusercontent.com/20992645/86056265-ced5e480-ba22-11ea-8f12-4f5e64681e28.png">

Fixes #218 

