### PR TITLE
PR: Add find widget to the terminal

### DIFF
--- a/spyder_terminal/server/static/js/main.js
+++ b/spyder_terminal/server/static/js/main.js
@@ -98,15 +98,15 @@ window.onresize = (event) => {
   fitAddon.fit();
 }
 
-function searchNext(regex) {
-  if(searchAddon.findNext(regex)){
+function searchNext(regex, options) {
+  if(searchAddon.findNext(regex, options)){
     return term.getSelectionPosition();
   }
   return -1;
 }
 
-function searchPrevious(regex) {
-  if(searchAddon.findPrevious(regex)){
+function searchPrevious(regex, options) {
+  if(searchAddon.findPrevious(regex, options)){
     return term.getSelectionPosition();
   }
   return -1;

--- a/spyder_terminal/terminalplugin.py
+++ b/spyder_terminal/terminalplugin.py
@@ -33,10 +33,10 @@ from spyder.widgets.tabs import Tabs
 from spyder.utils.misc import select_port
 
 # Local imports
+from spyder_terminal.widgets.findwidget import FindTerminal
 from spyder_terminal.widgets.terminalgui import TerminalWidget
 from spyder_terminal.confpage import TerminalConfigPage
 from spyder_terminal.config import CONF_DEFAULTS, CONF_VERSION, CONF_SECTION
-
 
 # Constants
 LOCATION = osp.realpath(osp.join(os.getcwd(),
@@ -91,6 +91,8 @@ class TerminalPlugin(SpyderPluginWidget):
         self.project_path = None
         self.current_file_path = None
         self.current_cwd = os.getcwd()
+        self.find_widget = FindTerminal(self)
+        self.find_widget.hide()
 
         try:
             # Spyder 3
@@ -124,6 +126,7 @@ class TerminalPlugin(SpyderPluginWidget):
         self.tabwidget.set_close_function(self.close_term)
 
         layout.addWidget(self.tabwidget)
+        layout.addWidget(self.find_widget)
         self.setLayout(layout)
 
         self.color_scheme = CONF.get('appearance', 'ui_theme')
@@ -333,6 +336,7 @@ class TerminalPlugin(SpyderPluginWidget):
         term = TerminalWidget(self, self.port, path=path, font=font.family(),
                               theme=self.theme, color_scheme=self.color_scheme)
         self.register_widget_shortcuts(term)
+        self.register_widget_shortcuts(self.find_widget)
         self.add_tab(term)
         term.terminal_closed.connect(lambda: self.close_term(term=term))
 
@@ -375,6 +379,18 @@ class TerminalPlugin(SpyderPluginWidget):
     def server_is_ready(self):
         """Return server status."""
         return self.server_ready
+
+    def search_next(self, text, case=False, regex=False, word=False):
+        """Search in the current terminal for the given regex."""
+        term = self.get_current_term()
+        if term:
+            term.search_next(text, case=case, regex=regex, word=word)
+
+    def search_previous(self, text, case=False, regex=False, word=False):
+        """Search in the current terminal for the given regex."""
+        term = self.get_current_term()
+        if term:
+            term.search_previous(text, case=case, regex=regex, word=word)
 
     # ------ Public API (for tabs) ---------------------------
     def add_tab(self, widget):

--- a/spyder_terminal/tests/test_terminal.py
+++ b/spyder_terminal/tests/test_terminal.py
@@ -215,38 +215,30 @@ def test_terminal_find(setup_terminal, qtbot_module):
     # Search without any special parameters
     text = 'ls'
     found = term.search_next(text)
-    found = False if found == -1 else True
-    assert found
+    assert found != -1
     found = term.search_previous(text)
-    found = False if found == -1 else True
-    assert found
+    assert found != -1
 
     # Search with case sensitive search
     text = 'ls'
     found = term.search_next(text, case=True)
-    found = False if found == -1 else True
-    assert found
+    assert found != -1
     found = term.search_previous(text, case=True)
-    found = False if found == -1 else True
-    assert found
+    assert found != -1
 
     # Search with the regex option
     text = r'/\((.*?)\)/'
     found = term.search_next(text, regex=True)
-    found = False if found == -1 else True
-    assert found
+    assert found != -1
     found = term.search_previous(text, regex=True)
-    found = False if found == -1 else True
-    assert found
+    assert found != -1
 
     # Search whole word option
     text = 'ls'
     found = term.search_next(text, word=True)
-    found = False if found == -1 else True
-    assert found
+    assert found != -1
     found = term.search_previous(text, word=True)
-    found = False if found == -1 else True
-    assert found
+    assert found != -1
 
 
 def test_terminal_font(setup_terminal, qtbot_module):

--- a/spyder_terminal/tests/test_terminal.py
+++ b/spyder_terminal/tests/test_terminal.py
@@ -198,6 +198,57 @@ def test_terminal_color(setup_terminal, qtbot_module):
     qtbot_module.waitUntil(lambda: check_hex_to_rgb(term),  timeout=TERM_UP)
 
 
+def test_terminal_find(setup_terminal, qtbot_module):
+    """Test the terminal find next/previous functions."""
+    terminal = setup_terminal
+    qtbot_module.waitUntil(lambda: terminal.server_is_ready(), timeout=TERM_UP)
+    qtbot_module.wait(1000)
+
+    term = terminal.get_current_term()
+    port = terminal.port
+    status_code = requests.get('http://127.0.0.1:{}'.format(port)).status_code
+    assert status_code == 200
+
+    term.exec_cmd('ls')
+    qtbot_module.wait(1000)
+
+    # Search without any special parameters
+    text = 'ls'
+    found = term.search_next(text)
+    found = False if found == -1 else True
+    assert found
+    found = term.search_previous(text)
+    found = False if found == -1 else True
+    assert found
+
+    # Search with case sensitive search
+    text = 'ls'
+    found = term.search_next(text, case=True)
+    found = False if found == -1 else True
+    assert found
+    found = term.search_previous(text, case=True)
+    found = False if found == -1 else True
+    assert found
+
+    # Search with the regex option
+    text = r'/\((.*?)\)/'
+    found = term.search_next(text, regex=True)
+    found = False if found == -1 else True
+    assert found
+    found = term.search_previous(text, regex=True)
+    found = False if found == -1 else True
+    assert found
+
+    # Search whole word option
+    text = 'ls'
+    found = term.search_next(text, word=True)
+    found = False if found == -1 else True
+    assert found
+    found = term.search_previous(text, word=True)
+    found = False if found == -1 else True
+    assert found
+
+
 def test_terminal_font(setup_terminal, qtbot_module):
     """Test if terminal loads a custom font."""
     terminal = setup_terminal

--- a/spyder_terminal/widgets/findwidget.py
+++ b/spyder_terminal/widgets/findwidget.py
@@ -1,0 +1,70 @@
+
+from qtpy.QtCore import Slot
+from qtpy.QtWidgets import (QGridLayout, QHBoxLayout, QLabel,
+                            QSizePolicy, QWidget)
+
+from spyder.utils.misc import regexp_error_msg
+from spyder.widgets.findreplace import FindReplace
+
+
+class FindTerminal(FindReplace):
+    """Find in terminal widget."""
+
+    def __init__(self, parent):
+        super().__init__(parent, enable_replace=False)
+        self.parent = parent
+
+    def show(self, hide_replace=False):
+        """Overrides Qt Method"""
+        QWidget.show(self)
+        self.visibility_changed.emit(True)
+        self.search_text.setFocus()
+
+    @Slot()
+    def hide(self):
+        """Overrides Qt Method"""
+        QWidget.hide(self)
+        self.visibility_changed.emit(False)
+
+    @Slot(bool)
+    def toggle_highlighting(self, state):
+        """Override the method from FindReplace widget."""
+        pass
+
+    def highlight_matches(self):
+        """Override the method from FindReplace widget."""
+        pass
+
+    def clear_matches(self):
+        """Override the method from FindReplace widget."""
+        pass
+
+    def find(self, changed=True, forward=True, rehighlight=False,
+             start_highlight_timer=False, multiline_replace_check=False):
+        """Call the find function"""
+        text = self.search_text.currentText()
+        if len(text) == 0:
+            self.search_text.lineEdit().setStyleSheet("")
+            return None
+        else:
+            case = self.case_button.isChecked()
+            word = self.words_button.isChecked()
+            regexp = self.re_button.isChecked()
+            if forward:
+                found = self.parent.search_next(text, case=case,
+                                                regex=regexp, word=word)
+            else:
+                found = self.parent.search_previous(text, case=case,
+                                                    regex=regexp, word=word)
+
+            found = False if found == -1 else True
+            stylesheet = self.STYLE[found]
+            tooltip = self.TOOLTIP[found]
+            if not found and regexp:
+                error_msg = regexp_error_msg(text)
+                if error_msg:  # special styling for regexp errors
+                    stylesheet = self.STYLE['regexp_error']
+                    tooltip = self.TOOLTIP['regexp_error'] + ': ' + error_msg
+            self.search_text.lineEdit().setStyleSheet(stylesheet)
+            self.search_text.setToolTip(tooltip)
+            return found

--- a/spyder_terminal/widgets/findwidget.py
+++ b/spyder_terminal/widgets/findwidget.py
@@ -1,3 +1,8 @@
+# -*- coding: utf-8 -*-
+#
+# Copyright © Spyder Project Contributors
+# Licensed under the terms of the MIT License
+#
 
 from qtpy.QtCore import Slot
 from qtpy.QtWidgets import (QGridLayout, QHBoxLayout, QLabel,

--- a/spyder_terminal/widgets/terminalgui.py
+++ b/spyder_terminal/widgets/terminalgui.py
@@ -7,6 +7,7 @@
 # -----------------------------------------------------------------------------
 """Terminal Widget."""
 # Standard library imports
+import json
 import os
 import sys
 
@@ -163,13 +164,22 @@ class TerminalWidget(QFrame):
         """List terminal CSS fonts."""
         return self.eval_javascript('getFonts()')
 
-    def search_next(self, regex):
+    def search_next(self, text, case=False, regex=False, word=False):
         """Search in the terminal for the given regex."""
-        return self.eval_javascript('searchNext("{}")'.format(regex))
+        search_options = {'regex': regex,
+                          'wholeWord': word,
+                          'caseSensitive': case}
+        return self.eval_javascript(
+            'searchNext("{}",{})'.format(text, json.dumps(search_options)))
 
-    def search_previous(self, regex):
+    def search_previous(self, text, case=False, regex=False, word=False):
         """Search in the terminal for the given regex."""
-        return self.eval_javascript('searchPrevious("{}")'.format(regex))
+        search_options = {'regex': regex,
+                          'wholeWord': word,
+                          'caseSensitive': case}
+        return self.eval_javascript(
+            'searchPrevious("{}", {})'.format(text,
+                                              json.dumps(search_options)))
 
     def exec_cmd(self, cmd):
         """Execute a command inside the terminal."""


### PR DESCRIPTION
Add the widget for finding text in the terminal

![image](https://user-images.githubusercontent.com/20992645/86858903-2f9a9800-c087-11ea-887f-3ed8d75fed61.png)

Now the terminal is able to find with all the options of the rest of the panes in Spyder

Fixes #224 