### PR TITLE
PR: Add scrollback option to the terminal

### DIFF
--- a/spyder_terminal/config.py
+++ b/spyder_terminal/config.py
@@ -20,7 +20,7 @@ CONF_DEFAULTS = [
       'sound': True,
       'cursor_type': 0,
       'shell': 'cmd' if WINDOWS else 'bash',
-      'buffer_lim': 1000
+      'buffer_limit': 1000
      }
      ),
     ('shortcuts',

--- a/spyder_terminal/config.py
+++ b/spyder_terminal/config.py
@@ -19,7 +19,8 @@ CONF_DEFAULTS = [
      {
       'sound': True,
       'cursor_type': 0,
-      'shell': 'cmd' if WINDOWS else 'bash'
+      'shell': 'cmd' if WINDOWS else 'bash',
+      'buffer_lim': 1000
      }
      ),
     ('shortcuts',

--- a/spyder_terminal/confpage.py
+++ b/spyder_terminal/confpage.py
@@ -71,7 +71,7 @@ class TerminalConfigPage(PluginConfigPage):
         display_layout = QVBoxLayout()
         # Custom buffer limit
         self.buffer_sb = self.create_spinbox(_("Buffer limit: "), "",
-                                             'buffer_lim', min_=100,
+                                             'buffer_limit', min_=100,
                                              default=1000,
                                              max_=1000000, step=1)
         display_layout.addWidget(self.buffer_sb)

--- a/spyder_terminal/confpage.py
+++ b/spyder_terminal/confpage.py
@@ -66,6 +66,19 @@ class TerminalConfigPage(PluginConfigPage):
         shell_layout.addStretch(1)
         options_layout.addWidget(shell_group)
 
+        # Display preferences
+        display_group = QGroupBox(_("Terminal display preferences"))
+        display_layout = QVBoxLayout()
+        # Custom buffer limit
+        self.buffer_sb = self.create_spinbox(_("Buffer limit: "), "",
+                                             'buffer_lim', min_=100,
+                                             default=1000,
+                                             max_=1000000, step=1)
+        display_layout.addWidget(self.buffer_sb)
+        display_group.setLayout(display_layout)
+        display_layout.addStretch(1)
+        options_layout.addWidget(display_group)
+
         # Style preferences
         terminal_group = QGroupBox(_("Terminal style preferences"))
         # Custom bar option
@@ -75,13 +88,6 @@ class TerminalConfigPage(PluginConfigPage):
                                                  'cursor_type')
         self.cursor_combo.combobox.setMinimumContentsLength(15)
         options_layout.addWidget(self.cursor_combo)
-
-        # Custom buffer limit
-        self.buffer_sb = self.create_spinbox(_("Buffer limit: "), "",
-                                             'buffer_lim', min_=100,
-                                             default=1000,
-                                             max_=1000000, step=1)
-        options_layout.addWidget(self.buffer_sb)
 
         # Custom sound option
         self.sound_cb = self.create_checkbox(
@@ -93,6 +99,7 @@ class TerminalConfigPage(PluginConfigPage):
 
         layout = QVBoxLayout()
         layout.addWidget(shell_group)
+        layout.addWidget(display_group)
         layout.addWidget(terminal_group)
         layout.addStretch(1)
 

--- a/spyder_terminal/confpage.py
+++ b/spyder_terminal/confpage.py
@@ -76,18 +76,19 @@ class TerminalConfigPage(PluginConfigPage):
         self.cursor_combo.combobox.setMinimumContentsLength(15)
         options_layout.addWidget(self.cursor_combo)
 
-        # Custom sound option
-        self.sound_cb = self.create_checkbox(
-            _("Enable bell sound"), 'sound',
-            tip=_("Enable bell sound on terminal"))
-        options_layout.addWidget(self.sound_cb)
-
         # Custom buffer limit
         self.buffer_sb = self.create_spinbox(_("Buffer limit: "), "",
                                              'buffer_lim', min_=100,
                                              default=1000,
                                              max_=1000000, step=1)
         options_layout.addWidget(self.buffer_sb)
+
+        # Custom sound option
+        self.sound_cb = self.create_checkbox(
+            _("Enable bell sound"), 'sound',
+            tip=_("Enable bell sound on terminal"))
+        options_layout.addWidget(self.sound_cb)
+
         terminal_group.setLayout(options_layout)
 
         layout = QVBoxLayout()

--- a/spyder_terminal/confpage.py
+++ b/spyder_terminal/confpage.py
@@ -82,6 +82,12 @@ class TerminalConfigPage(PluginConfigPage):
             tip=_("Enable bell sound on terminal"))
         options_layout.addWidget(self.sound_cb)
 
+        # Custom buffer limit
+        self.buffer_sb = self.create_spinbox(_("Buffer limit: "), "",
+                                             'buffer_lim', min_=100,
+                                             default=1000,
+                                             max_=1000000, step=1)
+        options_layout.addWidget(self.buffer_sb)
         terminal_group.setLayout(options_layout)
 
         layout = QVBoxLayout()

--- a/spyder_terminal/widgets/terminalgui.py
+++ b/spyder_terminal/widgets/terminalgui.py
@@ -217,6 +217,9 @@ class TerminalWidget(QFrame):
             color_scheme = CONF.get('appearance', 'ui_theme')
             theme = CONF.get('appearance', 'selected')
             self.set_theme(theme, color_scheme)
+        if 'buffer_lim' in options:
+            new_lim = options['buffer_lim']
+            self.set_option('scrollback', new_lim)
 
 
 class TermView(QWebEngineView):

--- a/spyder_terminal/widgets/terminalgui.py
+++ b/spyder_terminal/widgets/terminalgui.py
@@ -217,8 +217,8 @@ class TerminalWidget(QFrame):
             color_scheme = CONF.get('appearance', 'ui_theme')
             theme = CONF.get('appearance', 'selected')
             self.set_theme(theme, color_scheme)
-        if 'buffer_lim' in options:
-            new_lim = options['buffer_lim']
+        if 'buffer_limit' in options:
+            new_lim = options['buffer_limit']
             self.set_option('scrollback', new_lim)
 
 


### PR DESCRIPTION
This option allows the user to define the number of buffer lines in the terminal

![image](https://user-images.githubusercontent.com/20992645/87102952-2d684300-c219-11ea-8418-fc1cc53cb292.png)

Fixes #227 