### PR TITLE
PR: Add new cursor option and zoom to the terminal

### DIFF
--- a/spyder_terminal/config.py
+++ b/spyder_terminal/config.py
@@ -20,7 +20,9 @@ CONF_DEFAULTS = [
       'sound': True,
       'cursor_type': 0,
       'shell': 'cmd' if WINDOWS else 'bash',
-      'buffer_limit': 1000
+      'buffer_limit': 1000,
+      'cursor_blink': True,
+      'zoom': 0,
      }
      ),
     ('shortcuts',

--- a/spyder_terminal/confpage.py
+++ b/spyder_terminal/confpage.py
@@ -95,6 +95,12 @@ class TerminalConfigPage(PluginConfigPage):
             tip=_("Enable bell sound on terminal"))
         options_layout.addWidget(self.sound_cb)
 
+        # Visual bell option
+        self.cursor_blink_cb = self.create_checkbox(
+            _("Enable cursor blink"), 'cursor_blink',
+            tip=_("_Enable cursor blink on terminal"))
+        options_layout.addWidget(self.cursor_blink_cb)
+
         terminal_group.setLayout(options_layout)
 
         layout = QVBoxLayout()

--- a/spyder_terminal/widgets/terminalgui.py
+++ b/spyder_terminal/widgets/terminalgui.py
@@ -107,6 +107,7 @@ class TerminalWidget(QFrame, SpyderWidgetMixin):
         for option in options:
             dict_options[option] = self.get_conf(option)
         self.apply_settings(dict_options)
+        self.apply_zoom()
 
     def get_shortcut_data(self):
         """
@@ -201,10 +202,23 @@ class TerminalWidget(QFrame, SpyderWidgetMixin):
         alive = self.eval_javascript('isAlive()')
         return alive
 
+    def apply_zoom(self):
+        zoom = self.get_conf('zoom')
+        if zoom > 0:
+            for __ in range(0, zoom):
+                self.view.increase_font()
+        if zoom < 0:
+            for __ in range(0, -zoom):
+                self.view.decrease_font()
+
     def set_option(self, option_name, option):
         """Set a configuration option in the terminal."""
-        self.eval_javascript('setOption("{}", "{}")'.format(option_name,
-                                                            option))
+        if type(option) == int:
+            self.eval_javascript('setOption("{}", {})'.format(option_name,
+                                                              option))
+        else:
+            self.eval_javascript('setOption("{}", "{}")'.format(option_name,
+                                                                option))
 
     def apply_settings(self, options):
         """Apply custom settings given an option dictionary."""
@@ -220,6 +234,8 @@ class TerminalWidget(QFrame, SpyderWidgetMixin):
         if 'buffer_limit' in options:
             new_lim = options['buffer_limit']
             self.set_option('scrollback', new_lim)
+        if 'cursor_blink' in options:
+            self.set_option('cursorBlink', int(options['cursor_blink']))
 
 
 class TermView(QWebEngineView, SpyderWidgetMixin):
@@ -288,10 +304,14 @@ class TermView(QWebEngineView, SpyderWidgetMixin):
 
     def increase_font(self):
         """Increase terminal font."""
+        zoom = self.get_conf('zoom')
+        self.set_conf('zoom', zoom+1)
         return self.eval_javascript('increaseFontSize()')
 
     def decrease_font(self):
         """Decrease terminal font."""
+        zoom = self.get_conf('zoom')
+        self.set_conf('zoom', zoom-1)
         return self.eval_javascript('decreaseFontSize()')
 
     def contextMenuEvent(self, event):

--- a/spyder_terminal/widgets/terminalgui.py
+++ b/spyder_terminal/widgets/terminalgui.py
@@ -305,13 +305,13 @@ class TermView(QWebEngineView, SpyderWidgetMixin):
     def increase_font(self):
         """Increase terminal font."""
         zoom = self.get_conf('zoom')
-        self.set_conf('zoom', zoom+1)
+        self.set_conf('zoom', zoom + 1)
         return self.eval_javascript('increaseFontSize()')
 
     def decrease_font(self):
         """Decrease terminal font."""
         zoom = self.get_conf('zoom')
-        self.set_conf('zoom', zoom-1)
+        self.set_conf('zoom', zoom - 1)
         return self.eval_javascript('decreaseFontSize()')
 
     def contextMenuEvent(self, event):


### PR DESCRIPTION
This PR adds two features:

- Add the capability to enable/disable the cursor to blink

![image](https://user-images.githubusercontent.com/20992645/122135838-edd1b000-ce06-11eb-9420-6aab4b458da5.png)

- Saves the zoom used by the user and it is used by default when opening new terminals

zoom out:

![image](https://user-images.githubusercontent.com/20992645/122135857-f75b1800-ce06-11eb-9ea9-cc033e43bfbb.png)

zoom in:

![image](https://user-images.githubusercontent.com/20992645/122135918-12c62300-ce07-11eb-9627-42955a0a1dd6.png)


Fixes #247
