### PR TITLE
PR: Add blue border when the terminal is focused

### DIFF
--- a/spyder_terminal/widgets/main_widget.py
+++ b/spyder_terminal/widgets/main_widget.py
@@ -9,10 +9,11 @@
 
 # Standard imports
 import os
-import sys
+import os.path as osp
+import qstylizer
 import requests
 import subprocess
-import os.path as osp
+import sys
 
 # Third party imports
 from qtpy.QtCore import Signal, QTimer, Slot
@@ -112,6 +113,10 @@ class TerminalMainWidget(PluginMainWidget):
         layout.addWidget(self.tabwidget)
         layout.addWidget(self.find_widget)
         self.setLayout(layout)
+
+        css = qstylizer.style.StyleSheet()
+        css.QTabWidget.pane.setValues(border=0)
+        self.setStyleSheet(css.toString())
 
         self.__wait_server_to_start()
 

--- a/spyder_terminal/widgets/main_widget.py
+++ b/spyder_terminal/widgets/main_widget.py
@@ -11,7 +11,6 @@
 import os
 import os.path as osp
 import requests
-import subprocess
 import sys
 
 # Third party imports

--- a/spyder_terminal/widgets/main_widget.py
+++ b/spyder_terminal/widgets/main_widget.py
@@ -10,12 +10,12 @@
 # Standard imports
 import os
 import os.path as osp
-import qstylizer
 import requests
 import subprocess
 import sys
 
 # Third party imports
+import qstylizer
 from qtpy.QtCore import Signal, QTimer, Slot
 from qtpy.QtWidgets import QMessageBox, QVBoxLayout
 from spyder.api.config.decorators import on_conf_change

--- a/spyder_terminal/widgets/terminalgui.py
+++ b/spyder_terminal/widgets/terminalgui.py
@@ -86,7 +86,7 @@ class TerminalWidget(QFrame, SpyderWidgetMixin):
         layout = QVBoxLayout()
         layout.addWidget(self.view)
         layout.setContentsMargins(0, 0, 0, 0)
-        self.setFrameStyle(QFrame.StyledPanel | QFrame.Sunken)
+        self.setFrameStyle(QFrame.NoFrame)
         self.setLayout(layout)
 
         self.body = self.view.document

--- a/spyder_terminal/widgets/terminalgui.py
+++ b/spyder_terminal/widgets/terminalgui.py
@@ -9,10 +9,10 @@
 # Standard library imports
 import json
 import os
-import qstylizer
 import sys
 
 # Third-party imports
+import qstylizer
 from qtpy.QtCore import (Qt, QUrl, Slot, QEvent, QTimer, Signal,
                          QObject)
 from qtpy.QtGui import QKeySequence

--- a/spyder_terminal/widgets/terminalgui.py
+++ b/spyder_terminal/widgets/terminalgui.py
@@ -86,7 +86,7 @@ class TerminalWidget(QFrame, SpyderWidgetMixin):
         layout = QVBoxLayout()
         layout.addWidget(self.view)
         layout.setContentsMargins(0, 0, 0, 0)
-        self.setFrameStyle(QFrame.NoFrame)
+        self.setFrameStyle(QFrame.NoFrame | QFrame.Plain)
         self.setLayout(layout)
 
         self.body = self.view.document

--- a/spyder_terminal/widgets/terminalgui.py
+++ b/spyder_terminal/widgets/terminalgui.py
@@ -19,16 +19,12 @@ from qtpy.QtGui import QKeySequence
 from qtpy.QtWebChannel import QWebChannel
 from qtpy.QtWebEngineWidgets import (QWebEnginePage, QWebEngineSettings,
                                      QWebEngineView)
-from qtpy.QtWidgets import QMenu, QFrame, QVBoxLayout, QWidget, QApplication
+from qtpy.QtWidgets import QFrame, QVBoxLayout, QApplication
 from spyder.api.widgets.mixins import SpyderWidgetMixin
 from spyder.api.config.decorators import on_conf_change
-from spyder.config.base import DEV, get_translation
-from spyder.config.manager import CONF
+from spyder.config.base import get_translation
 from spyder.config.gui import is_dark_interface
-from spyder.utils import icon_manager as ima
 from spyder.utils.palette import QStylePalette
-from spyder.utils.qthelpers import create_action, add_actions
-from spyder.widgets.browser import FrameWebView
 
 # Local imports
 from spyder_terminal.api import TerminalMainWidgetActions, TermViewMenus


### PR DESCRIPTION
This PR adds a blue border when the widget is focused,

Focused:
![image](https://user-images.githubusercontent.com/20992645/123330049-20fcf900-d503-11eb-96f2-19c1739a4bf2.png)


Not Focused:
![image](https://user-images.githubusercontent.com/20992645/123330025-19d5eb00-d503-11eb-85ec-d7a533a6b520.png)

Note: I was unable to use Spyder's `FrameWebView ` class because the WebView and QFrame of spyder-terminal diverge greatly from that implementation.