### PR TITLE
PR: Update installation instructions for conda

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -81,7 +81,9 @@ Using conda:
 
 ::
 
-    conda install spyder-terminal -c spyder-ide
+    conda create -n spyder-env -c conda-forge spyder-terminal
+    conda activate spyder-env
+    spyder
 
 Using pip (only if you don't use conda!):
 


### PR DESCRIPTION
- It's not possible to install Spyder-terminal from our own channel (even if we copy the conda-forge packages to it), so we need to tell people to create a new environment with conda-forge instead.
- See for instance the following issue for an example of the current behavior: #288