### PR TITLE
PR: Update to Spyder 5.2.x API

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -17,13 +17,6 @@ main: &main
           command: ./continuous_integration/circle/runtests.sh || ./continuous_integration/circle/runtests.sh
 
 jobs:
-  python3.6:
-    <<: *main
-    environment:
-      - PYTHON_VERSION: "3.6"
-      - USE_CONDA: "yes"
-      - CODECOV_TOKEN: "273c981b-7851-4895-a4bb-07377c67791e"
-
   python3.7:
     <<: *main
     environment:
@@ -49,7 +42,6 @@ workflows:
   version: 2
   build_and_test:
     jobs:
-      - python3.6
       - python3.7
       - python3.8
       - python3.9

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -20,8 +20,6 @@ jobs:
   # Run the pipeline with multiple Python versions
   strategy:
     matrix:
-      Python36:
-        python.version: '3.6'
       Python37:
         python.version: '3.7'
       Python38:
@@ -98,9 +96,6 @@ jobs:
   # Run the pipeline with multiple Python versions
   strategy:
     matrix:
-      Python36:
-        python.version: '3.6'
-        use.conda: "yes"
       Python37:
         python.version: '3.7'
         use.conda: "yes"

--- a/requirements/conda.txt
+++ b/requirements/conda.txt
@@ -1,4 +1,4 @@
-spyder>=5.1.1
+spyder>=5.2.0
 pexpect
 tornado
 coloredlogs

--- a/requirements/conda_win.txt
+++ b/requirements/conda_win.txt
@@ -1,4 +1,4 @@
-spyder>=5.1.1
+spyder>=5.2.0
 pywinpty==1.1.3
 tornado
 coloredlogs

--- a/spyder_terminal/terminalplugin.py
+++ b/spyder_terminal/terminalplugin.py
@@ -45,6 +45,7 @@ class TerminalPlugin(SpyderDockablePlugin):
     CONF_WIDGET_CLASS = TerminalConfigPage
     CONF_DEFAULTS = CONF_DEFAULTS
     CONF_VERSION = CONF_VERSION
+    CAN_BE_DISABLED = False
 
     # --- Signals
     # ------------------------------------------------------------------------

--- a/spyder_terminal/terminalplugin.py
+++ b/spyder_terminal/terminalplugin.py
@@ -55,7 +55,8 @@ class TerminalPlugin(SpyderDockablePlugin):
 
     # ---- SpyderDockablePlugin API
     # ------------------------------------------------------------------------
-    def get_name(self):
+    @staticmethod
+    def get_name():
         """Return plugin title."""
         return _('Terminal')
 


### PR DESCRIPTION
This PR updates to Spyder 5.2.x API,

- [x] Changes `get_name` function into a static method
- [x] Bumps Spyder minimum version to 5.2
- [x] Adds attribute to prevent the disabling of the plugin
- [x] Removes support for Python 3.6