### PR TITLE
PR: Fix double zoom when openning a new terminal

### DIFF
--- a/spyder_terminal/tests/test_terminal.py
+++ b/spyder_terminal/tests/test_terminal.py
@@ -416,3 +416,47 @@ def test_conda_path(setup_terminal, qtbot_module):
     # Try to deactivate the current environment
     term.exec_cmd("conda deactivate")
     qtbot_module.waitUntil(lambda: check_output(term, "base"), timeout=TERM_UP)
+
+
+def test_zoom(setup_terminal, qtbot_module):
+    """Test zoom level is increasing and decreasing."""
+    terminal = setup_terminal
+    qtbot_module.waitUntil(
+        lambda: terminal.get_widget().server_is_ready(), timeout=TERM_UP)
+    qtbot_module.wait(1000)
+
+    term = terminal.get_widget().get_current_term()
+    original_zoom = term.get_conf("zoom")
+
+    term.view.increase_font()
+    term.view.increase_font()
+    term.view.increase_font()
+
+    # Check the zoom increases three times
+    assert term.get_conf("zoom") == original_zoom + 3
+
+    term.view.decrease_font()
+    term.view.decrease_font()
+
+    # Check the zoom decreases two times
+    assert term.get_conf("zoom") == original_zoom + 1
+
+
+def test_zoom_new_term(setup_terminal, qtbot_module):
+    """Test zoom level is correct when creating a new terminal."""
+    terminal = setup_terminal
+    qtbot_module.waitUntil(
+        lambda: terminal.get_widget().server_is_ready(), timeout=TERM_UP)
+    qtbot_module.wait(1000)
+
+    term = terminal.get_widget().get_current_term()
+
+    term.view.increase_font()
+    term.view.increase_font()
+    term1_zoom = term.get_conf("zoom")
+
+    terminal.create_new_term()
+    term = terminal.get_widget().get_current_term()
+    new_zoom = term.get_conf("zoom")
+
+    assert term1_zoom == new_zoom

--- a/spyder_terminal/widgets/terminalgui.py
+++ b/spyder_terminal/widgets/terminalgui.py
@@ -237,10 +237,10 @@ class TerminalWidget(QFrame, SpyderWidgetMixin):
         zoom = self.get_conf('zoom')
         if zoom > 0:
             for __ in range(0, zoom):
-                self.view.increase_font()
+                self.view.increase_font(new_term=True)
         if zoom < 0:
             for __ in range(0, -zoom):
-                self.view.decrease_font()
+                self.view.decrease_font(new_term=True)
 
     def set_option(self, option_name, option):
         """Set a configuration option in the terminal."""
@@ -361,16 +361,18 @@ class TermView(QWebEngineView, SpyderWidgetMixin):
         """Clear the terminal."""
         self.eval_javascript('clearTerm()')
 
-    def increase_font(self):
+    def increase_font(self, new_term=False):
         """Increase terminal font."""
-        zoom = self.get_conf('zoom')
-        self.set_conf('zoom', zoom + 1)
+        if not new_term:
+            zoom = self.get_conf('zoom')
+            self.set_conf('zoom', zoom + 1)
         return self.eval_javascript('increaseFontSize()')
 
-    def decrease_font(self):
+    def decrease_font(self, new_term=False):
         """Decrease terminal font."""
-        zoom = self.get_conf('zoom')
-        self.set_conf('zoom', zoom - 1)
+        if not new_term:
+            zoom = self.get_conf('zoom')
+            self.set_conf('zoom', zoom - 1)
         return self.eval_javascript('decreaseFontSize()')
 
     def contextMenuEvent(self, event):


### PR DESCRIPTION
This PR avoids double decreasing/increasing zoom when a new terminal is created

Fixes #302 