### PR TITLE
PR: Update pywinpty version to v2.0.5

### DIFF
--- a/requirements/conda_win.txt
+++ b/requirements/conda_win.txt
@@ -1,5 +1,5 @@
 spyder>=5.2.0
-pywinpty==2.0.1
+pywinpty==2.0.5
 tornado
 coloredlogs
 requests


### PR DESCRIPTION
The latest pywinpty release fixes some issues with terminado console termination as well CI issues that arose when `windows-2019` was used.