### PR TITLE
PR: Improve shell startup

### DIFF
--- a/spyder_terminal/server/common.py
+++ b/spyder_terminal/server/common.py
@@ -6,6 +6,24 @@ import os.path
 import spyder_terminal.server.routes as routes
 from spyder_terminal.server.logic.term_manager import TermManager
 
+# These shell options ensure proper startup in "interactive login" mode
+SHOPTS = {
+    'bash': ['-i', '-l'],
+    'zsh': ['-i', '-l'],
+    'fish': ['-i', '-l'],
+    'sh': ['-i', '-l'],
+    'ksh': ['-i', '-l'],
+    'csh': ['-i', '-l'],
+    'pwsh': [],
+    'rbash': ['-i', '-l'],
+    'dash': ['-i', '-l'],
+    'screen': ['-l'],
+    'tmux': [],
+    'tcsh': ['-i', '-l'],
+    'xonsh': [],
+    'cmd': []
+}
+
 
 def create_app(shell, close_future=None):
     """Create and return a tornado Web Application instance."""
@@ -15,5 +33,6 @@ def create_app(shell, close_future=None):
                                           debug=True,
                                           serve_traceback=True,
                                           autoreload=True, **settings)
-    application.term_manager = TermManager([shell])
+    shell_base = os.path.basename(shell).split('.')[0]
+    application.term_manager = TermManager([shell] + SHOPTS[shell_base])
     return application

--- a/spyder_terminal/widgets/terminalgui.py
+++ b/spyder_terminal/widgets/terminalgui.py
@@ -65,24 +65,6 @@ class ChannelHandler(QObject):
 
 class TerminalWidget(QFrame, SpyderWidgetMixin):
     """Terminal widget."""
-    zdotdir = os.environ.get('ZDOTDIR') or os.environ.get('HOME')  # what about windows?
-    ENV_ROUTES = {
-        "bash": ["/etc/profile", "~/.bash_profile"],
-        "zsh": ["/etc/zshenv", f"{zdotdir}/.zshenv", "/etc/zprofile",
-                f"{zdotdir}/.zprofile", "/etc/zshrc", f"{zdotdir}/.zshrc",
-                "/etc/zlogin", f"{zdotdir}/.zlogin"],
-        "fish": ["~/.config/fish/config.fish"],
-        "sh": ["~/.profile", "~/.shrc", "~/.shinit"],
-        "ksh": ["~/.profile", "~/.kshrc"],
-        "csh": ["~/.cshrc", "~/.login"],
-        "pwsh": [],
-        "rbash": ["~/.bashrc", "~/.bash_profile"],
-        "dash": ["~/.profile"],
-        "screen": [],
-        "tmux": [],
-        "tcsh": ["~/.tcshrc"],
-        "xonsh": ["~/.xonshrc"]
-    }
 
     terminal_closed = Signal()
     terminal_ready = Signal()
@@ -130,15 +112,6 @@ class TerminalWidget(QFrame, SpyderWidgetMixin):
             dict_options[option] = self.get_conf(option)
         self.apply_settings(dict_options)
         self.apply_zoom()
-        shell_name = self.get_conf('shell')
-        if os.name != 'nt':
-            # Find environment variables in the home directory given the actual
-            # shell
-            env_route = self.ENV_ROUTES[shell_name]
-            for act_file in env_route:
-                if os.path.exists(os.path.expanduser(act_file)):
-                    self.exec_cmd(f"source {act_file}")
-                    self.exec_cmd("clear")
 
     def get_shortcut_data(self):
         """


### PR DESCRIPTION
Terminal startup to use interactive and login flags rather than source startup files explicitly.

This should more easily achieve the expected terminal environment as it uses the shell's own mechanisms for launch startup.