### PR TITLE
check for 'bsd' in sys.platform, using sh as a default shell

### DIFF
--- a/spyder_terminal/confpage.py
+++ b/spyder_terminal/confpage.py
@@ -50,6 +50,8 @@ class TerminalConfigPage(PluginConfigPage):
             default_option = 'cmd'
         elif sys.platform.startswith('linux'):
             default_option = 'bash'
+        elif 'bsd' in sys.platform:
+            default_option = 'sh'
         else:
             mac_ver = LooseVersion(platform.mac_ver()[0])
             if mac_ver >= LooseVersion('10.15.0'):


### PR DESCRIPTION
On BSD platforms, the `sys.platform` test for a default shell in confpage.py may fall through to the Darwin case. This may result in an error as follows, also preventing the display of the Spyder Preferences window.

```
Traceback (most recent call last):
  File "/usr/home/gimbal/wk/python_wk/spyder_sandbox/env/lib/python3.11/site-packages/spyder/plugins/preferences/plugin.py", line 276, in <lambda>
    lambda: self.open_dialog(main.prefs_dialog_size))
            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/home/gimbal/wk/python_wk/spyder_sandbox/env/lib/python3.11/site-packages/spyder/plugins/preferences/plugin.py", line 256, in open_dialog
    container.create_dialog(
  File "/usr/home/gimbal/wk/python_wk/spyder_sandbox/env/lib/python3.11/site-packages/spyder/plugins/preferences/widgets/container.py", line 58, in create_dialog
    page.initialize()
  File "/usr/home/gimbal/wk/python_wk/spyder_sandbox/env/lib/python3.11/site-packages/spyder/plugins/preferences/api.py", line 86, in initialize
    self.setup_page()
  File "/usr/home/gimbal/wk/python_wk/spyder_sandbox/env/lib/python3.11/site-packages/spyder_terminal/confpage.py", line 55, in setup_page
    if mac_ver >= LooseVersion('10.15.0'):
       ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/home/gimbal/wk/python_wk/spyder_sandbox/env/lib/python3.11/site-packages/setuptools/_distutils/version.py", line 90, in __ge__
    c = self._cmp(other)
        ^^^^^^^^^^^^^^^^
  File "/usr/home/gimbal/wk/python_wk/spyder_sandbox/env/lib/python3.11/site-packages/setuptools/_distutils/version.py", line 350, in _cmp
    if self.version == other.version:
       ^^^^^^^^^^^^
AttributeError: 'LooseVersion' object has no attribute 'version'
```

This patch adds a test for 'bsd' in `sys.platform`, here using 'sh' as a default shell for confpage.py

When the Spyder Issue reporter popped up with this issue, I'd originally [reported it to the spyder project](https://github.com/spyder-ide/spyder/issues/20667). Noticing the source references in the backtrace available in the Issue reporter window, I'll try to retract or close the issue there.