### PR TITLE
Replace deprecated distutils and pipes modules

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -45,7 +45,8 @@ REQUIREMENTS = [
     'tornado',
     'terminado>=0.13.1',
     'coloredlogs',
-    'requests'
+    'requests',
+    'looseversion'
 ]
 
 EXTRAS_REQUIRE = {

--- a/setupbase.py
+++ b/setupbase.py
@@ -17,23 +17,25 @@ setupbase definition
 See: https://github.com/jupyter/notebook/blob/master/setupbase.py
 """
 
+import logging
 import os
 import os.path as osp
-import pipes
+import shlex
 import shutil
 import sys
 
-from distutils import log
-from distutils.core import Command
+from setuptools import Command
 from setuptools.command.develop import develop
 from setuptools.command.sdist import sdist
 from subprocess import check_call
+
+log = logging.getLogger()
 
 if sys.platform == 'win32':
     from subprocess import list2cmdline
 else:
     def list2cmdline(cmd_list):
-        return ' '.join(map(pipes.quote, cmd_list))
+        return ' '.join(map(shlex.quote, cmd_list))
 
 
 HERE = os.path.abspath(os.path.dirname(__file__))

--- a/spyder_terminal/confpage.py
+++ b/spyder_terminal/confpage.py
@@ -7,10 +7,11 @@
 """Spyder terminal configuration page."""
 
 # Standard library imports
-from distutils.version import LooseVersion
 import os
 import platform
 import sys
+
+from looseversion import LooseVersion
 
 # Third party imports
 from qtpy.QtWidgets import (QVBoxLayout, QGroupBox, QGridLayout, QButtonGroup,


### PR DESCRIPTION
This addresses the points I made in https://github.com/spyder-ide/spyder-terminal/pull/349#issuecomment-2571781555 replacing `pipes` with `shlex` and `distutils` with `setuptools` and `looseversion`.

This patch can be applied after #349, but the package will not build without the updates there.