### PR TITLE
PR: Use `sh` as a default shell on BSD systems

### DIFF
--- a/spyder_terminal/confpage.py
+++ b/spyder_terminal/confpage.py
@@ -47,6 +47,8 @@ class TerminalConfigPage(PluginConfigPage):
             default_option = 'cmd'
         elif sys.platform.startswith('linux'):
             default_option = 'bash'
+        elif 'bsd' in sys.platform:
+            default_option = 'sh'
         else:
             default_option = 'zsh'
         shell_combo = self.create_combobox(_("Select the shell interpreter:"),


### PR DESCRIPTION
Supersedes PR #341

Fixes #342 